### PR TITLE
Allow properties containing vendor name separated by comma

### DIFF
--- a/crates/dt-analyzer/test_data/1/expected.json
+++ b/crates/dt-analyzer/test_data/1/expected.json
@@ -1,4 +1,5 @@
 {
   "foo": ["Hello, world!", [18, 52, 86]],
-  "bar": [[1]]
+  "bar": [[1]],
+  "vendor,baz": true
 }

--- a/crates/dt-analyzer/test_data/1/source.dts
+++ b/crates/dt-analyzer/test_data/1/source.dts
@@ -6,4 +6,5 @@
 
 / {
   bar = <1>;
+  vendor,baz;
 };

--- a/crates/dt-lint/src/kernel_coding_style.rs
+++ b/crates/dt-lint/src/kernel_coding_style.rs
@@ -16,9 +16,10 @@ fn valid_node_unit_name(s: &str) -> bool {
     (s.chars().all(|c| matches!(c, '0'..='9' | 'a'..='f')) && !s.starts_with('0')) || s == "0"
 }
 fn valid_prop_name(s: &str) -> bool {
-    s.chars().enumerate().all(|(i, c)| {
-        c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-' || (i == 0 && c == '#')
-    })
+    s.chars().filter(|c| c == &',').count() == 1
+        || s.chars().enumerate().all(|(i, c)| {
+            c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-' || (i == 0 && c == '#')
+        })
 }
 fn valid_label_name(s: &str) -> bool {
     s.chars()
@@ -79,7 +80,7 @@ impl EarlyLintPass for KernelCodingStyle {
             if text != "device_type" && text != "ddr_device_type" && !valid_prop_name(text) {
                 cx.add_lint_from_cst(
                     LintId::KernelCodingStyle,
-                    format!("Property name `{text}` should match `#?[a-z0-9-]+`"),
+                    format!("Property name `{text}` should match `#?[a-z0-9-,]+`"),
                     LintSeverity::Warn,
                     name.syntax().text_range(),
                 );

--- a/crates/dt-lint/src/kernel_coding_style.rs
+++ b/crates/dt-lint/src/kernel_coding_style.rs
@@ -16,10 +16,19 @@ fn valid_node_unit_name(s: &str) -> bool {
     (s.chars().all(|c| matches!(c, '0'..='9' | 'a'..='f')) && !s.starts_with('0')) || s == "0"
 }
 fn valid_prop_name(s: &str) -> bool {
-    s.chars().filter(|c| c == &',').count() == 1
-        || s.chars().enumerate().all(|(i, c)| {
-            c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-' || (i == 0 && c == '#')
-        })
+    let mut count = 0;
+    s.chars().enumerate().all(|(i, c)| {
+        let is_vendor_property = i != 0 && c == ',';
+        if is_vendor_property {
+            count += 1;
+        }
+
+        c.is_ascii_lowercase()
+            || c.is_ascii_digit()
+            || c == '-'
+            || (i == 0 && c == '#')
+            || (is_vendor_property && count == 1)
+    })
 }
 fn valid_label_name(s: &str) -> bool {
     s.chars()


### PR DESCRIPTION
Example: `qcom,acc = <&acc0>;`